### PR TITLE
Add wercker.yml

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,33 @@
+# This references the default golang container from
+# the Docker Hub: https://registry.hub.docker.com/u/library/golang/
+# If you want Google's container you would reference google/golang
+# Read more about containers on our dev center
+# http://devcenter.wercker.com/docs/containers/index.html
+box: wercker/golang
+# This is the build pipeline. Pipelines are the core of wercker
+# Read more about pipelines on our dev center
+# http://devcenter.wercker.com/docs/pipelines/index.html
+
+build:
+  steps:
+    # Sets the go workspace and places the package
+    # at the right place in the workspace tree
+    - setup-go-workspace
+
+    # Gets the dependencies
+    - script:
+        name: go get
+        code: |
+          go get
+
+    # Build the project
+    - script:
+        name: go build
+        code: |
+          go build .
+
+    # Test the project
+    - script:
+        name: go test
+        code: |
+          go test .


### PR DESCRIPTION
Adding wercker.yml to fix the project's CI: the default wercker settings are not suitable because they include the build of examples which are mutually exclusive (they define multiple "main" func in "main" package).